### PR TITLE
feat(nginx): Change how ssl certs are used

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     restart: on-failure
     volumes:
       - ./build:/var/www/eisandbar/html
+      - /etc/letsencrypt:/etc/letsencrypt
 
   website:
     container_name: website

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,3 @@
 
 FROM nginx
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY ./ssl-certs /etc/nginx/ssl-certs

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,8 +20,8 @@ http {
         root /var/www/eisandbar/html;
         index index.html index.htm index.nginx-debian.html;
 
-        ssl_certificate /etc/nginx/ssl-certs/website.crt;
-        ssl_certificate_key /etc/nginx/ssl-certs/website.key;
+        ssl_certificate /etc/letsencrypt/live/eisandbar.me/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/eisandbar.me/privkey.pem;
 
         server_name eisandbar.me www.eisandbar.me localhost;
 


### PR DESCRIPTION
Instead of copying the certs to a ssl-certs directory , the container will now mount on /etc/letsencrypt and use them directly.