### PR TITLE
build: fix quote mark confusion in cloudbuild.yml

### DIFF
--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -2,4 +2,12 @@ steps:
   - name: "gcr.io/cloud-builders/gcloud" # cloud builder with gcloud installed
     id: Update live server
     entrypoint: /bin/sh
-    args: ['gcloud', 'compute', 'ssh', 'eisandbar@website', '--zone=us-east4-c', '--command='/bins/sh /home/eisandbar/website/pull.sh'']
+    args:
+      [
+        "gcloud",
+        "compute",
+        "ssh",
+        "eisandbar@website",
+        "--zone=us-east4-c",
+        "--command='/bins/sh /home/eisandbar/website/pull.sh'",
+      ]


### PR DESCRIPTION
Fixed confusion where quote marks were used inside an arg