### PR TITLE
build: Make nginx not fail when no upstream

### DIFF
--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -26,7 +26,8 @@ http {
         server_name eisandbar.me www.eisandbar.me localhost:3000;
 
         location / {
-            proxy_pass http://eisandbar-nginx;
+            set $eisandbar eisandbar-nginx;
+            proxy_pass http://$eisandbar;
         }
     }
 
@@ -41,7 +42,8 @@ http {
         server_name ytlive.online www.ytlive.online localhost:3001;
 
         location / {
-            proxy_pass http://ytlive-nginx;
+            set $ytlive ytlive-nginx
+            proxy_pass http://$ytlive;
         }
     }
 }


### PR DESCRIPTION
As these are independent applications using the same nginx reverse proxy the proxy server shouldn't fail when one of the apps is not present.

Changed proxy_pass to use variables as that seems to be the solution.