### PR TITLE
build: redirect port 80 and fix no upstream

### DIFF
--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -12,7 +12,7 @@ http {
 
         server_name _;
 
-        return 301 https://$host$request_uri
+        return 301 https://$host$request_uri;
     }
 
     server {
@@ -26,7 +26,9 @@ http {
         server_name eisandbar.me www.eisandbar.me localhost:3000;
 
         location / {
-            proxy_pass http://eisandbar-nginx;
+            resolver 127.0.0.11 valid=30s;
+            set $eisandbar eisandbar-nginx;
+            proxy_pass http://$eisandbar;
         }
     }
 
@@ -41,7 +43,9 @@ http {
         server_name ytlive.online www.ytlive.online localhost:3001;
 
         location / {
-            proxy_pass http://ytlive-nginx;
+            resolver 127.0.0.11 valid=30s;
+            set $ytlive ytlive-nginx;
+            proxy_pass http://$ytlive;
         }
     }
 }

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -8,9 +8,16 @@ http {
     ssl_session_timeout 1m;
 
     server {
+        listen 80 default_server;
+
+        server_name _;
+
+        return 301 https://$host$request_uri
+    }
+
+    server {
 
         listen 443 ssl;
-        listen 80;
         listen 3000;
 
         ssl_certificate /etc/letsencrypt/live/eisandbar.me/fullchain.pem;
@@ -26,7 +33,6 @@ http {
     server {
 
         listen 443 ssl;
-        listen 80;
         listen 3001;
 
         ssl_certificate /etc/letsencrypt/live/ytlive.online/fullchain.pem;


### PR DESCRIPTION
Have all requests to port 80 be redirected to port 443

Make so that reverse proxy doesn't fail even when no upstream hosts